### PR TITLE
Feat/exception 프로젝트 컨트롤러 예외 테스트 추가 및 글로벌 에러 핸들러 수정

### DIFF
--- a/sequence_member/src/main/java/sequence/sequence_member/global/exception/GlobalExceptionHandler.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/global/exception/GlobalExceptionHandler.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -80,6 +81,19 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ApiResponseData<String>> handleExpiredJwtException(ExpiredJwtException e){
         return ResponseEntity.status(Code.EXPIRED_TOKEN.getStatus()).body(ApiResponseData.of(Code.VALIDATION_ERROR.getCode(),
                 e.getMessage(),null));
+    }
+
+    // JWT 일반 오류 처리: 토큰 형식 및 구조, 지원 불가, 토큰 null 등
+    @ExceptionHandler(JwtException.class)
+    public ResponseEntity<ApiResponseData<String>> handleJwtException(JwtException e){
+        return ResponseEntity.status(Code.BAD_REQUEST.getStatus())
+                .body(ApiResponseData.of(Code.BAD_REQUEST.getCode(), "JWT 오류 발생: " +e.getMessage(),null));
+    }
+
+    // 필수 파라미터 누락
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<ApiResponseData<String>> handleMissingServletRequestParameterException(MissingServletRequestParameterException e){
+        return ResponseEntity.status(Code.VALIDATION_ERROR.getStatus()).body(ApiResponseData.of(Code.BAD_REQUEST.getCode(), "필수 파라미터 누락: " + e.getMessage(),null));
     }
 
 /**

--- a/sequence_member/src/test/java/sequence/sequence_member/project/controller/ProjectControllerExceptionTest.java
+++ b/sequence_member/src/test/java/sequence/sequence_member/project/controller/ProjectControllerExceptionTest.java
@@ -1,0 +1,43 @@
+package sequence.sequence_member.project.controller;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import sequence.sequence_member.global.exception.CanNotFindResourceException;
+import sequence.sequence_member.project.service.ProjectBookmarkService;
+import sequence.sequence_member.project.service.ProjectService;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(ProjectController.class)
+public class ProjectControllerExceptionTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private ProjectService projectService;
+    @MockBean
+    private ProjectBookmarkService projectBookmarkService;
+
+    // GET /api/projects/{projectId} 호출 시 존재하지 않는 프로젝트 404, 에러 메시지 반환 검증
+    // CanNotFindResourceException 글로벌 예외 핸들러 처리
+    @Test
+    public void testGetProjectNotFound() throws Exception {
+        // 프로젝트가 존재하지 않는 경우, 서비스에서 예외를 던짐
+        when(projectService.getProject(anyLong(), any(HttpServletRequest.class)))
+                .thenThrow(new CanNotFindResourceException("해당 프로젝트가 존재하지 않습니다."));
+
+        // /api/projects/1 엔드포인트 호출 후, 404 상태 코드와 에러 메시지 확인
+        mockMvc.perform(get("/api/projects/1"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message", containsString("해당 프로젝트가 존재하지 않습니다.")));
+    }
+}


### PR DESCRIPTION
1. **프로젝트 컨트롤러 예외 테스트 추가**  
   - `ProjectControllerExceptionTest.java` 파일을 추가하여, 존재하지 않는 프로젝트 조회 시 404 응답이 반환되는지 테스트
   - MockMvc를 사용해 글로벌 예외 핸들러와 통합하여, 올바른 에러 메시지와 HTTP 상태 코드가 반환되는지 검증

2. **글로벌 에러 핸들러 수정**  
   - `GlobalExceptionHandler.java` 파일을 수정하여, 아래와 같은 예외 상황을 추가로 처리
     - **필수 파라미터 누락 오류:** `MissingServletRequestParameterException` 처리
     -  **JWT 관련 오류:** 일반적인 JWT 오류를 처리하기 위한 `JwtException` 처리

