### PR TITLE
[feat]: 마이페이지 및 회원 정보에서 Skill enum ↔ string 변환 로직 추가

### DIFF
--- a/sequence_member/src/main/java/sequence/sequence_member/mypage/dto/BasicInfoDTO.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/mypage/dto/BasicInfoDTO.java
@@ -68,7 +68,7 @@ public class BasicInfoDTO {
     @NotNull(message = "학위는 필수 입력 값입니다.")
     private Degree degree;
 
-    private List<Skill> skillCategory;
+    private List<String> skillCategory;
     private List<ProjectRole> desiredJob;
 
     private String profileImg;

--- a/sequence_member/src/main/java/sequence/sequence_member/mypage/dto/MyPageMapper.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/mypage/dto/MyPageMapper.java
@@ -9,6 +9,7 @@ import sequence.sequence_member.archive.entity.Archive;
 import sequence.sequence_member.archive.repository.ArchiveBookmarkRepository;
 import sequence.sequence_member.archive.repository.ArchiveRepository;
 import sequence.sequence_member.archive.service.MyPageEvaluationService;
+import sequence.sequence_member.member.converter.SkillCategoryConverter;
 import sequence.sequence_member.member.entity.AwardEntity;
 import sequence.sequence_member.member.entity.CareerEntity;
 import sequence.sequence_member.member.entity.ExperienceEntity;
@@ -40,6 +41,7 @@ public class MyPageMapper {
     private final CareerRepository careerRepository;
     private final AwardRepository awardRepository;
     private final PortfolioRepository portfolioRepository;
+    private final SkillCategoryConverter skillCategoryConverter;
 
     /**
      * 멤버와 아카이브 페이지네이션 객체를 ResponseDTO 매핑하는 메인 함수입니다.
@@ -83,7 +85,7 @@ public class MyPageMapper {
                 .entranceYear(member.getEducation().getEntranceYear())
                 .graduationYear(member.getEducation().getGraduationYear())
                 .degree(member.getEducation().getDegree())
-                .skillCategory(member.getEducation().getSkillCategory())
+                .skillCategory(skillCategoryConverter.convertToSkillString(member.getEducation().getSkillCategory()))
                 .desiredJob(member.getEducation().getDesiredJob())
                 .profileImg(member.getProfileImg())
                 .build();

--- a/sequence_member/src/main/java/sequence/sequence_member/mypage/dto/MyPageRequestDTO.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/mypage/dto/MyPageRequestDTO.java
@@ -60,7 +60,7 @@ public class MyPageRequestDTO {
     @NotNull(message = "학위는 필수 입력 값입니다.")
     private Degree degree;
 
-    private List<Skill> skillCategory;
+    private List<String> skillCategory;
     private List<ProjectRole> desiredJob;
 
     private List<AwardDTO> awards;

--- a/sequence_member/src/main/java/sequence/sequence_member/mypage/service/MyPageUpdateService.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/mypage/service/MyPageUpdateService.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import sequence.sequence_member.global.utils.MultipartUtil;
+import sequence.sequence_member.member.converter.SkillCategoryConverter;
 import sequence.sequence_member.member.entity.AwardEntity;
 import sequence.sequence_member.member.entity.CareerEntity;
 import sequence.sequence_member.member.entity.EducationEntity;
@@ -43,6 +44,7 @@ public class MyPageUpdateService {
     private final CareerRepository careerRepository;
     private final ExperienceRepository experienceRepository;
     private final EducationRepository educationRepository;
+    private final SkillCategoryConverter skillCategoryConverter;
 
     /**
      * 주어진 사용자 정보를 바탕으로 마이페이지를 업데이트합니다.
@@ -232,7 +234,7 @@ public class MyPageUpdateService {
                         myPageDTO.getEntranceYear(),
                         myPageDTO.getGraduationYear(),
                         myPageDTO.getDegree(),
-                        myPageDTO.getSkillCategory(),
+                        skillCategoryConverter.convertToSkillEnum(myPageDTO.getSkillCategory()),
                         myPageDTO.getDesiredJob()
                 ),
                 () -> {
@@ -243,7 +245,7 @@ public class MyPageUpdateService {
                             myPageDTO.getEntranceYear(),
                             myPageDTO.getGraduationYear(),
                             myPageDTO.getDegree(),
-                            myPageDTO.getSkillCategory(),
+                            skillCategoryConverter.convertToSkillEnum(myPageDTO.getSkillCategory()),
                             myPageDTO.getDesiredJob(),
                             member
                     );


### PR DESCRIPTION
[목적]
- Skill enum 값을 API 응답 시 string으로 변환하여 반환
- 마이페이지 수정에서도 string 값을 받아 enum으로 변환해 저장하도록 처리

[변경 내용]
- Skill enum을 string으로 매핑하여 반환하는 변환 로직 추가
- 마이페이지 수정 요청 DTO에서 string skill 값을 enum으로 변환하는 처리 추가
- 회원가입 시와 동일한 방식으로 skill 필드 처리 통일