### PR TITLE
refactor: 아카이브 목록 DTO 매핑 방식 변경 및 최적화

### DIFF
--- a/sequence_member/src/main/java/sequence/sequence_member/mypage/controller/MyPageController.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/mypage/controller/MyPageController.java
@@ -12,7 +12,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
@@ -33,14 +32,12 @@ public class MyPageController {
 
     @GetMapping("/api/mypage")
     public ResponseEntity<ApiResponseData<MyPageResponseDTO>> getMyProfile(
-            @RequestParam(defaultValue = "0") int page,  // 페이지 기본값 0
-            @RequestParam(defaultValue = "10") int size,  // 사이즈 기본값 10
             @AuthenticationPrincipal CustomUserDetails customUserDetails
     ) {
         String username = customUserDetails.getUsername();
 
         try {
-            MyPageResponseDTO myPageDTO = myPageService.getMyProfile(username, page, size, customUserDetails);
+            MyPageResponseDTO myPageDTO = myPageService.getMyProfile(username, customUserDetails);
             // 성공 응답 생성
             return ResponseEntity.ok(ApiResponseData.success(myPageDTO, "사용자 정보를 성공적으로 가져왔습니다."));
         } catch (Exception e) {
@@ -73,12 +70,10 @@ public class MyPageController {
     @GetMapping("/api/mypage/{nickname}")
     public ResponseEntity<ApiResponseData<MyPageResponseDTO>> getUserProfile(
             @PathVariable String nickname,
-            @RequestParam(defaultValue = "0") int page,  // 페이지 기본값 0
-            @RequestParam(defaultValue = "10") int size,   // 사이즈 기본값 10
             @AuthenticationPrincipal CustomUserDetails customUserDetails
     ) {
         try {
-            MyPageResponseDTO userProfile = myPageService.getUserProfile(nickname, page, size, customUserDetails);
+            MyPageResponseDTO userProfile = myPageService.getUserProfile(nickname, customUserDetails);
             return ResponseEntity.ok(ApiResponseData.success(userProfile, nickname + "님의 정보를 성공적으로 가져왔습니다."));
         } catch (Exception e) {
             ApiResponseData errorResponse = ApiResponseData.failure(

--- a/sequence_member/src/main/java/sequence/sequence_member/mypage/dto/MyPageMapper.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/mypage/dto/MyPageMapper.java
@@ -1,7 +1,6 @@
 package sequence.sequence_member.mypage.dto;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Component;
 import sequence.sequence_member.archive.dto.MyPageEvaluationDTO;
@@ -47,18 +46,18 @@ public class MyPageMapper {
      * 멤버와 아카이브 페이지네이션 객체를 ResponseDTO 매핑하는 메인 함수입니다.
      *
      * @param member ResponseDTO로 매핑할 멤버 객체
-     * @param archivePage ResponseDTO로 매핑할 archive 페이지네이션 객체
+     * @param archiveList ResponseDTO로 매핑할 archive 페이지네이션 객체
      * @return 사용자의 마이페이지 정보를 담은 MyPageResponseDTO
      */
     public MyPageResponseDTO toMyPageResponseDto(
             MemberEntity member,
-            Page<Archive> archivePage,
+            List<Archive> archiveList,
             List<InvitedProjectWithCommentDTO> invitedProjects
     ) {
         return new MyPageResponseDTO(
                 toBasicInfoDto(member),
                 toCareerHistoryDto(member),
-                toPortfolioDto(archivePage, invitedProjects),
+                toPortfolioDto(archiveList, invitedProjects),
                 toTeamFeedbackDto(member),
                 getMyActivity(member)
         );
@@ -140,17 +139,19 @@ public class MyPageMapper {
     /**
      * 내가 작성한 아카이브와 초대받은 프로젝트 리스트를 PortfolioDTO로 변환합니다.
      *
-     * @param archivePage
+     * @param archiveList
      * @return PortfolioDto 객체
      */
-    private PortfolioDTO toPortfolioDto(Page<Archive> archivePage, List<InvitedProjectWithCommentDTO> invitedProjects) {
-        Page<ArchiveSummaryDTO> archiveDTO = archivePage.map(archive -> ArchiveSummaryDTO.builder()
-                .id(archive.getId())
-                .title(archive.getTitle())
-                .thumbnail(archive.getThumbnail())
-                .startDate(archive.getStartDate())
-                .endDate(archive.getEndDate())
-                .build());
+    private PortfolioDTO toPortfolioDto(List<Archive> archiveList, List<InvitedProjectWithCommentDTO> invitedProjects) {
+        List<ArchiveSummaryDTO> archiveDTO = archiveList.stream()
+                .map(archive -> ArchiveSummaryDTO.builder()
+                    .id(archive.getId())
+                    .title(archive.getTitle())
+                    .thumbnail(archive.getThumbnail())
+                    .startDate(archive.getStartDate())
+                    .endDate(archive.getEndDate())
+                    .build())
+                .collect(Collectors.toList());
 
         return new PortfolioDTO(archiveDTO, invitedProjects);
     }

--- a/sequence_member/src/main/java/sequence/sequence_member/mypage/dto/PortfolioDTO.java
+++ b/sequence_member/src/main/java/sequence/sequence_member/mypage/dto/PortfolioDTO.java
@@ -3,19 +3,17 @@ package sequence.sequence_member.mypage.dto;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.domain.Page;
 
 import java.util.List;
 
 /**
  * 사용자가 참여한 아카이브 이력 DTO
- *
  * 마이페이지 화면에서 '포트폴리오'에 해당하는 객체
  */
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
 public class PortfolioDTO {
-    private Page<ArchiveSummaryDTO> archivePage;
+    private List<ArchiveSummaryDTO> archiveList;
     private List<InvitedProjectWithCommentDTO> invitedProjects;
 }


### PR DESCRIPTION
[목적]
- 아카이브 목록 데이터 처리 방식을 `Page`에서 `List` 기반으로 변경하고 DTO 매핑을 일관되게 적용

[변경 내용]
- `toPortfolioDto` 메서드의 `archiveList` 파라미터 타입을 `Page<Archive>`에서 `List<Archive>`로 변경